### PR TITLE
fix: replace unwrap-panic with safe errors

### DIFF
--- a/contracts/billing.clar
+++ b/contracts/billing.clar
@@ -234,12 +234,12 @@
         (not (get payment-status subscription))))
 
 (define-read-only (get-user-payment (payment-id uint) (user principal))
-    (let ((payment (map-get? payment-history { payment-id: payment-id })))
-        (if (and 
-            (is-some payment)
-            (is-eq (get user (unwrap-panic payment)) user))
-            payment
-            none)))
+    (match (map-get? payment-history { payment-id: payment-id })
+        payment
+        (if (is-eq (get user payment) user)
+            (some payment)
+            none)
+        none))
 
 (define-read-only (get-subscription-status (user principal))
     (let ((subscription (default-to

--- a/contracts/billing.clar
+++ b/contracts/billing.clar
@@ -134,10 +134,11 @@
          (promo (map-get? promotional-rates { promo-id: promo-id })))
         (let
             ((payment-id (+ (var-get payment-counter) u1))
-             (discount-rate (if (and 
-                                (is-some promo)
-                                (< stacks-block-height (get valid-until (unwrap-panic promo))))
-                            (get discount-percentage (unwrap-panic promo))
+             (discount-rate (match promo
+                            promo-val
+                            (if (< stacks-block-height (get valid-until promo-val))
+                                (get discount-percentage promo-val)
+                                u0)
                             u0)))
             (begin
                 (unwrap! (process-subscription-payment (get price plan-details) tx-sender)

--- a/contracts/billing.clar
+++ b/contracts/billing.clar
@@ -13,6 +13,8 @@
 (define-constant err-no-subscription (err u204))
 (define-constant err-grace-period-expired (err u205))
 (define-constant err-invalid-discount (err u206))
+(define-constant err-promo-not-found (err u207))
+(define-constant err-payment-not-found (err u208))
 
 ;; Data Structures
 (define-map user-subscriptions

--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -90,8 +90,8 @@
             (user tx-sender)
             (plan (unwrap! (map-get? data-plans { plan-id: plan-id }) (err err-invalid-plan)))
             (current-usage (map-get? user-data-usage { user: user }))
-            (raw-rollover (if (is-some current-usage)
-                (get rollover-data (unwrap-panic current-usage))
+            (raw-rollover (match current-usage
+                usage-data (get rollover-data usage-data)
                 u0))
             (max-rollover (* (get data-amount plan) (var-get rollover-cap-multiplier)))
             (rollover-amount (if (> raw-rollover max-rollover)

--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -9,6 +9,7 @@
 (define-constant err-expired-plan (err u103))
 (define-constant err-plan-exists (err u104))
 (define-constant err-invalid-plan (err u105))
+(define-constant err-data-not-found (err u106))
 
 ;; Data Plan Types
 (define-constant plan-daily u1)

--- a/tests/billing_test.ts
+++ b/tests/billing_test.ts
@@ -327,4 +327,60 @@ describe("billing contract", () => {
     );
     expect(result).toBeErr(Cl.uint(200));
   });
+
+  it("get-user-payment returns none for wrong user", () => {
+    simnet.callPublicFn(
+      "data-tracking",
+      "set-data-plan",
+      [Cl.uint(1), Cl.uint(500), Cl.uint(144), Cl.uint(50000000)],
+      deployer
+    );
+    simnet.callPublicFn(
+      "billing",
+      "subscribe-and-pay",
+      [
+        Cl.uint(1),
+        Cl.contractPrincipal(deployer, "data-tracking"),
+        Cl.uint(0),
+      ],
+      wallet1
+    );
+
+    const result = simnet.callReadOnlyFn(
+      "billing",
+      "get-user-payment",
+      [Cl.uint(1), Cl.principal(wallet2)],
+      wallet2
+    );
+    expect(result.result).toBeNone();
+  });
+
+  it("get-user-payment returns payment for correct user", () => {
+    simnet.callPublicFn(
+      "data-tracking",
+      "set-data-plan",
+      [Cl.uint(1), Cl.uint(500), Cl.uint(144), Cl.uint(50000000)],
+      deployer
+    );
+    simnet.callPublicFn(
+      "billing",
+      "subscribe-and-pay",
+      [
+        Cl.uint(1),
+        Cl.contractPrincipal(deployer, "data-tracking"),
+        Cl.uint(0),
+      ],
+      wallet1
+    );
+
+    const result = simnet.callReadOnlyFn(
+      "billing",
+      "get-user-payment",
+      [Cl.uint(1), Cl.principal(wallet1)],
+      wallet1
+    );
+    expect(result.result).toBeSome(
+      expect.objectContaining({ type: expect.any(Number) })
+    );
+  });
 });


### PR DESCRIPTION
Replace all unwrap-panic with safe unwrap! and match. Add new error constants.