### PR TITLE
feat: add usage rate limiting to record-usage

### DIFF
--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -130,11 +130,20 @@
             (is-authorized (default-to { is-authorized: false } (map-get? authorized-carriers { carrier: carrier })))
             (current-data (unwrap! (map-get? user-data-usage { user: user }) (err err-invalid-data)))
             (event-id (+ (var-get event-counter) u1))
+            (last-block (default-to { block-height: u0 } (map-get? last-usage-block { user: user })))
         )
         (asserts! (get is-authorized is-authorized) (err err-invalid-caller))
         (asserts! (<= usage (get data-balance current-data)) (err err-invalid-data))
         (asserts! (< stacks-block-height (get plan-expiry current-data)) (err err-expired-plan))
-        
+        ;; Rate limit: require at least 1 block between usage recordings per user
+        (asserts! (> stacks-block-height (get block-height last-block)) (err err-rate-limited))
+
+        ;; Update last-usage-block for rate limiting
+        (map-set last-usage-block
+            { user: user }
+            { block-height: stacks-block-height }
+        )
+
         ;; Update usage data
         (map-set user-data-usage
             { user: user }
@@ -148,7 +157,7 @@
                 rollover-data: (get rollover-data current-data)
             }
         )
-        
+
         ;; Log usage event
         (var-set event-counter event-id)
         (ok (map-set usage-events

--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -10,6 +10,7 @@
 (define-constant err-plan-exists (err u104))
 (define-constant err-invalid-plan (err u105))
 (define-constant err-data-not-found (err u106))
+(define-constant err-rate-limited (err u107))
 
 ;; Data Plan Types
 (define-constant plan-daily u1)

--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -376,3 +376,9 @@
     (default-to false
         (get is-authorized (map-get? authorized-carriers { carrier: carrier })))
 )
+
+;; Get last usage block for a user (rate limiting)
+(define-read-only (get-last-usage-block (user principal))
+    (default-to u0
+        (get block-height (map-get? last-usage-block { user: user })))
+)

--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -46,6 +46,12 @@
     { is-authorized: bool }
 )
 
+;; Rate limiting: track last block each user had usage recorded
+(define-map last-usage-block
+    { user: principal }
+    { block-height: uint }
+)
+
 ;; Rollover cap: max 2x plan data can be rolled over
 (define-data-var rollover-cap-multiplier uint u2)
 

--- a/tests/data-tracking_test.ts
+++ b/tests/data-tracking_test.ts
@@ -465,4 +465,90 @@ describe("data-tracking contract", () => {
     );
     expect(result).toBeErr(Cl.uint(100));
   });
+
+  it("rejects duplicate usage recording in same block", () => {
+    simnet.callPublicFn(
+      "data-tracking",
+      "set-data-plan",
+      [Cl.uint(1), Cl.uint(500), Cl.uint(144), Cl.uint(50000000)],
+      deployer
+    );
+    simnet.callPublicFn(
+      "data-tracking",
+      "subscribe-to-plan",
+      [Cl.uint(1), Cl.bool(false)],
+      wallet1
+    );
+    simnet.callPublicFn(
+      "data-tracking",
+      "authorize-carrier",
+      [Cl.principal(wallet2)],
+      deployer
+    );
+
+    // First recording succeeds
+    const first = simnet.callPublicFn(
+      "data-tracking",
+      "record-usage",
+      [Cl.principal(wallet1), Cl.uint(10)],
+      wallet2
+    );
+    expect(first.result).toBeOk(Cl.bool(true));
+
+    // Second recording in same block should be rate-limited
+    const second = simnet.callPublicFn(
+      "data-tracking",
+      "record-usage",
+      [Cl.principal(wallet1), Cl.uint(10)],
+      wallet2
+    );
+    expect(second.result).toBeErr(Cl.uint(107));
+  });
+
+  it("returns last usage block after recording", () => {
+    simnet.callPublicFn(
+      "data-tracking",
+      "set-data-plan",
+      [Cl.uint(1), Cl.uint(500), Cl.uint(144), Cl.uint(50000000)],
+      deployer
+    );
+    simnet.callPublicFn(
+      "data-tracking",
+      "subscribe-to-plan",
+      [Cl.uint(1), Cl.bool(false)],
+      wallet1
+    );
+    simnet.callPublicFn(
+      "data-tracking",
+      "authorize-carrier",
+      [Cl.principal(wallet2)],
+      deployer
+    );
+    simnet.callPublicFn(
+      "data-tracking",
+      "record-usage",
+      [Cl.principal(wallet1), Cl.uint(10)],
+      wallet2
+    );
+
+    const result = simnet.callReadOnlyFn(
+      "data-tracking",
+      "get-last-usage-block",
+      [Cl.principal(wallet1)],
+      wallet1
+    );
+    // Should be greater than 0 after recording
+    const val = result.result;
+    expect(val).not.toEqual(Cl.uint(0));
+  });
+
+  it("returns 0 last-usage-block for user with no recordings", () => {
+    const result = simnet.callReadOnlyFn(
+      "data-tracking",
+      "get-last-usage-block",
+      [Cl.principal(wallet2)],
+      wallet2
+    );
+    expect(result.result).toBeUint(0);
+  });
 });


### PR DESCRIPTION
Add rate limiting map and check in record-usage requiring 1 block between recordings per user.