### PR TITLE
fix: improve marketplace error codes

### DIFF
--- a/contracts/marketplace.clar
+++ b/contracts/marketplace.clar
@@ -11,6 +11,8 @@
 (define-constant err-listing-expired (err u303))
 (define-constant err-not-seller (err u304))
 (define-constant err-insufficient-funds (err u305))
+(define-constant err-listing-not-found (err u306))
+(define-constant err-self-purchase (err u307))
 
 ;; Marketplace fee: 2% of listing price goes to platform
 (define-data-var marketplace-fee-rate uint u200) ;; basis points (200 = 2%)

--- a/contracts/marketplace.clar
+++ b/contracts/marketplace.clar
@@ -144,10 +144,11 @@
     (tracking-contract <data-tracking-trait>))
     (let
         ((listing (unwrap! (map-get? data-listings { listing-id: listing-id })
-                          (err err-invalid-listing))))
+                          (err err-listing-not-found))))
         (begin
             (asserts! (get is-active listing) (err err-listing-expired))
             (asserts! (<= stacks-block-height (get expiry listing)) (err err-listing-expired))
+            (asserts! (not (is-eq tx-sender (get seller listing))) (err err-self-purchase))
             
             ;; Process payment with marketplace fee
             (unwrap! (process-payment-with-fee (get price listing) tx-sender (get seller listing))

--- a/contracts/marketplace.clar
+++ b/contracts/marketplace.clar
@@ -109,7 +109,7 @@
 
 (define-public (cancel-listing (listing-id uint))
     (let ((listing (unwrap! (map-get? data-listings { listing-id: listing-id })
-                           (err err-invalid-listing))))
+                           (err err-listing-not-found))))
         (asserts! (is-eq (get seller listing) tx-sender) (err err-not-seller))
         (asserts! (get is-active listing) (err err-listing-expired))
         (begin

--- a/tests/marketplace_test.ts
+++ b/tests/marketplace_test.ts
@@ -346,4 +346,49 @@ describe("marketplace contract", () => {
     );
     expect(result.result).toBeUint(0);
   });
+
+  it("prevents buyer from purchasing own listing", () => {
+    setupUserWithData();
+
+    simnet.callPublicFn(
+      "marketplace",
+      "create-listing",
+      [
+        Cl.uint(100),
+        Cl.uint(5000000),
+        Cl.uint(500),
+        Cl.contractPrincipal(deployer, "data-tracking"),
+      ],
+      wallet1
+    );
+
+    // Seller tries to buy their own listing
+    const { result } = simnet.callPublicFn(
+      "marketplace",
+      "purchase-listing",
+      [Cl.uint(1), Cl.contractPrincipal(deployer, "data-tracking")],
+      wallet1
+    );
+    expect(result).toBeErr(Cl.uint(307));
+  });
+
+  it("returns err-listing-not-found for nonexistent listing", () => {
+    const { result } = simnet.callPublicFn(
+      "marketplace",
+      "cancel-listing",
+      [Cl.uint(9999)],
+      wallet1
+    );
+    expect(result).toBeErr(Cl.uint(306));
+  });
+
+  it("returns err-listing-not-found when purchasing nonexistent listing", () => {
+    const { result } = simnet.callPublicFn(
+      "marketplace",
+      "purchase-listing",
+      [Cl.uint(9999), Cl.contractPrincipal(deployer, "data-tracking")],
+      wallet2
+    );
+    expect(result).toBeErr(Cl.uint(306));
+  });
 });


### PR DESCRIPTION
Add err-listing-not-found and err-self-purchase. Prevent self-purchase in purchase-listing. Distinguish listing not found from expired.