### PR TITLE
feat: add plan price validation with configurable max

### DIFF
--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -404,6 +404,10 @@
         (get is-authorized (map-get? authorized-carriers { carrier: carrier })))
 )
 
+;; Get max plan price setting
+(define-read-only (get-max-plan-price)
+    (var-get max-plan-price))
+
 ;; Get last usage block for a user (rate limiting)
 (define-read-only (get-last-usage-block (user principal))
     (default-to u0

--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -56,6 +56,9 @@
 ;; Rollover cap: max 2x plan data can be rolled over
 (define-data-var rollover-cap-multiplier uint u2)
 
+;; Max price for any plan (in microSTX) - default 1 billion microSTX = 1000 STX
+(define-data-var max-plan-price uint u1000000000)
+
 ;; Events
 (define-data-var event-counter uint u0)
 

--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -11,6 +11,7 @@
 (define-constant err-invalid-plan (err u105))
 (define-constant err-data-not-found (err u106))
 (define-constant err-rate-limited (err u107))
+(define-constant err-price-too-high (err u108))
 
 ;; Data Plan Types
 (define-constant plan-daily u1)

--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -321,6 +321,9 @@
     (begin
         (asserts! (is-eq tx-sender contract-owner) (err err-owner-only))
         (asserts! (is-some (map-get? data-plans { plan-id: plan-id })) (err err-invalid-plan))
+        (asserts! (> price u0) (err err-invalid-data))
+        (asserts! (<= price (var-get max-plan-price)) (err err-price-too-high))
+        (asserts! (> data-amount u0) (err err-invalid-data))
         (ok (map-set data-plans
             { plan-id: plan-id }
             {
@@ -331,6 +334,15 @@
             }
         ))
     )
+)
+
+;; Admin: configure the maximum allowed price for a plan
+(define-public (set-max-plan-price (new-max uint))
+    (begin
+        (asserts! (is-eq tx-sender contract-owner) (err err-owner-only))
+        (asserts! (> new-max u0) (err err-invalid-data))
+        (var-set max-plan-price new-max)
+        (ok true))
 )
 
 ;; Get usage data (trait-compatible wrapper)

--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -82,6 +82,7 @@
         (asserts! (> data-amount u0) (err err-invalid-data))
         (asserts! (> duration-blocks u0) (err err-invalid-data))
         (asserts! (> price u0) (err err-invalid-data))
+        (asserts! (<= price (var-get max-plan-price)) (err err-price-too-high))
         (ok (map-set data-plans
             { plan-id: plan-id }
             {

--- a/tests/data-tracking_test.ts
+++ b/tests/data-tracking_test.ts
@@ -551,4 +551,61 @@ describe("data-tracking contract", () => {
     );
     expect(result.result).toBeUint(0);
   });
+
+  it("returns default max plan price", () => {
+    const result = simnet.callReadOnlyFn(
+      "data-tracking",
+      "get-max-plan-price",
+      [],
+      deployer
+    );
+    expect(result.result).toBeUint(1000000000);
+  });
+
+  it("rejects plan price exceeding max-plan-price", () => {
+    const { result } = simnet.callPublicFn(
+      "data-tracking",
+      "set-data-plan",
+      [Cl.uint(9), Cl.uint(100), Cl.uint(50), Cl.uint(2000000000)],
+      deployer
+    );
+    expect(result).toBeErr(Cl.uint(108));
+  });
+
+  it("allows owner to set max-plan-price", () => {
+    const { result } = simnet.callPublicFn(
+      "data-tracking",
+      "set-max-plan-price",
+      [Cl.uint(500000000)],
+      deployer
+    );
+    expect(result).toBeOk(Cl.bool(true));
+  });
+
+  it("prevents non-owner from setting max-plan-price", () => {
+    const { result } = simnet.callPublicFn(
+      "data-tracking",
+      "set-max-plan-price",
+      [Cl.uint(500000000)],
+      wallet1
+    );
+    expect(result).toBeErr(Cl.uint(100));
+  });
+
+  it("rejects zero price in update-plan", () => {
+    simnet.callPublicFn(
+      "data-tracking",
+      "set-data-plan",
+      [Cl.uint(1), Cl.uint(500), Cl.uint(144), Cl.uint(50000000)],
+      deployer
+    );
+
+    const { result } = simnet.callPublicFn(
+      "data-tracking",
+      "update-plan",
+      [Cl.uint(1), Cl.uint(500), Cl.uint(144), Cl.uint(0)],
+      deployer
+    );
+    expect(result).toBeErr(Cl.uint(102));
+  });
 });


### PR DESCRIPTION
Add max-plan-price var, price bounds validation in set-data-plan and update-plan, set-max-plan-price admin fn.