### PR TITLE
fix/clarity-trait-definitions: Fix invalid trait definitions causing clarinet check errors

### DIFF
--- a/contracts/billing.clar
+++ b/contracts/billing.clar
@@ -137,12 +137,13 @@
             }
         ))))
 
-(define-public (subscribe-and-pay 
-    (plan-id uint) 
+(define-public (subscribe-and-pay
+    (plan-id uint)
     (tracking-contract <data-tracking-trait>)
     (promo-id uint))
-    (let 
-        ((plan-details (unwrap! (contract-call? tracking-contract get-plan-details plan-id) 
+    ;; get-plan-details returns (response {...} uint) - unwrap! extracts the ok value
+    (let
+        ((plan-details (unwrap! (contract-call? tracking-contract get-plan-details plan-id)
                                (err err-invalid-plan)))
          (promo (map-get? promotional-rates { promo-id: promo-id })))
         (let

--- a/contracts/billing.clar
+++ b/contracts/billing.clar
@@ -2,7 +2,6 @@
 
 ;; Import traits
 (use-trait data-tracking-trait .data-traits.data-tracking-trait)
-(use-trait marketplace-trait .data-traits.marketplace-trait)
 
 ;; Constants
 (define-constant contract-owner tx-sender)

--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -383,9 +383,11 @@
     (map-get? user-data-usage { user: user })
 )
 
-;; Get plan details
+;; Get plan details (trait-compatible: returns response)
 (define-read-only (get-plan-details (plan-id uint))
-    (map-get? data-plans { plan-id: plan-id })
+    (match (map-get? data-plans { plan-id: plan-id })
+        plan (ok plan)
+        (err u999))
 )
 
 ;; Get usage event details

--- a/contracts/data-traits.clar
+++ b/contracts/data-traits.clar
@@ -29,5 +29,6 @@
         (create-listing (uint uint uint) (response uint uint))
         (cancel-listing (uint) (response bool uint))
         (purchase-listing (uint) (response bool uint))
+        (set-marketplace-fee-rate (uint) (response bool uint))
     )
 )

--- a/contracts/data-traits.clar
+++ b/contracts/data-traits.clar
@@ -1,3 +1,6 @@
+;; Trait definitions for DataChainAfrica contracts
+;; All return types use (response ok-type err-type) as required by Clarity 4
+
 (define-trait data-tracking-trait
     (
         ;; Get plan details

--- a/contracts/data-traits.clar
+++ b/contracts/data-traits.clar
@@ -1,12 +1,12 @@
 (define-trait data-tracking-trait
     (
-        ;; Get plan details (read-only)
-        (get-plan-details (uint) (optional {
+        ;; Get plan details
+        (get-plan-details (uint) (response {
             data-amount: uint,
             duration-blocks: uint,
             price: uint,
             is-active: bool
-        }))
+        } uint))
 
         ;; Subscribe to plan
         (subscribe-to-plan (uint bool) (response bool uint))

--- a/contracts/marketplace.clar
+++ b/contracts/marketplace.clar
@@ -1,6 +1,7 @@
 ;; marketplace.clar
 
 ;; Import traits
+;; get-usage returns (response {...} uint) - compatible with unwrap! in create-listing
 (use-trait data-tracking-trait .data-traits.data-tracking-trait)
 
 ;; Constants

--- a/tests/data-tracking_test.ts
+++ b/tests/data-tracking_test.ts
@@ -382,13 +382,14 @@ describe("data-tracking contract", () => {
 
     // The marketplace contract would call transfer-data-balance
     // Here we verify the function exists and authorization works
+    // get-plan-details now returns (response {...} uint) after trait fix
     const result = simnet.callReadOnlyFn(
       "data-tracking",
       "get-plan-details",
       [Cl.uint(1)],
       wallet1
     );
-    expect(result.result).toBeSome(
+    expect(result.result).toBeOk(
       expect.objectContaining({ type: expect.any(Number) })
     );
   });
@@ -410,13 +411,14 @@ describe("data-tracking contract", () => {
     expect(result).toBeOk(Cl.bool(true));
 
     // Verify plan is deactivated
+    // get-plan-details now returns (response {...} uint) after trait fix
     const plan = simnet.callReadOnlyFn(
       "data-tracking",
       "get-plan-details",
       [Cl.uint(5)],
       deployer
     );
-    expect(plan.result).toBeSome(
+    expect(plan.result).toBeOk(
       Cl.tuple({
         "data-amount": Cl.uint(1000),
         "duration-blocks": Cl.uint(288),


### PR DESCRIPTION
Fixes 3 errors reported by clarinet check caused by invalid trait syntax in data-traits.clar.

- Changed get-plan-details return type from (optional ...) to (response ... uint) in the trait definition
- Updated get-plan-details implementation in data-tracking.clar to return (response ...)
- Removed unused marketplace-trait import from billing.clar
- Confirmed billing.clar and marketplace.clar are compatible with the new response type
- Updated tests to use toBeOk() instead of toBeSome() for get-plan-details assertions

All 4 contracts now pass clarinet check with 0 errors.