### PR TITLE
feat: security hardening - emergency pause and low-balance alerts

### DIFF
--- a/contracts/data-tracking.clar
+++ b/contracts/data-tracking.clar
@@ -12,6 +12,14 @@
 (define-constant err-data-not-found (err u106))
 (define-constant err-rate-limited (err u107))
 (define-constant err-price-too-high (err u108))
+(define-constant err-contract-paused (err u109))
+(define-constant err-low-balance (err u110))
+
+;; Emergency pause
+(define-data-var contract-paused bool false)
+
+;; Low balance alert threshold (percentage of plan data, basis points: 1000 = 10%)
+(define-data-var low-balance-threshold uint u1000)
 
 ;; Data Plan Types
 (define-constant plan-daily u1)
@@ -79,6 +87,7 @@
 (define-public (set-data-plan (plan-id uint) (data-amount uint) (duration-blocks uint) (price uint))
     (begin
         (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+        (asserts! (not (var-get contract-paused)) err-contract-paused)
         ;; Validate plan-id before using as map key
         (asserts! (> plan-id u0) err-invalid-data)
         (asserts! (> data-amount u0) err-invalid-data)
@@ -102,6 +111,7 @@
     (let
         (
             (user tx-sender)
+            (not-paused (asserts! (not (var-get contract-paused)) err-contract-paused))
             ;; Validate plan-id before using as map key
             (valid-plan-id (asserts! (> plan-id u0) err-invalid-plan))
             (plan (unwrap! (map-get? data-plans { plan-id: plan-id }) err-invalid-plan))
@@ -359,6 +369,25 @@
     )
 )
 
+;; Emergency pause toggle
+(define-public (set-emergency-pause (paused bool))
+    (begin
+        (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+        (var-set contract-paused paused)
+        (print { action: "emergency-pause", paused: paused, by: tx-sender })
+        (ok true))
+)
+
+;; Set low balance alert threshold (in basis points of plan data)
+(define-public (set-low-balance-threshold (threshold uint))
+    (begin
+        (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+        (asserts! (> threshold u0) err-invalid-data)
+        (asserts! (<= threshold u5000) err-invalid-data) ;; max 50%
+        (var-set low-balance-threshold threshold)
+        (ok true))
+)
+
 ;; Admin: configure the maximum allowed price for a plan
 (define-public (set-max-plan-price (new-max uint))
     (begin
@@ -437,4 +466,30 @@
 (define-read-only (get-last-usage-block (user principal))
     (default-to u0
         (get block-height (map-get? last-usage-block { user: user })))
+)
+
+;; Check if user has low data balance (below threshold)
+(define-read-only (is-low-balance (user principal))
+    (match (map-get? user-data-usage { user: user })
+        data
+        (let (
+            (plan (default-to
+                { data-amount: u0, duration-blocks: u0, price: u0, is-active: false }
+                (map-get? data-plans { plan-id: (get plan-type data) })))
+            (threshold-amount (/ (* (get data-amount plan) (var-get low-balance-threshold)) u10000))
+        )
+            (<= (get data-balance data) threshold-amount)
+        )
+        false
+    )
+)
+
+;; Check if contract is paused
+(define-read-only (is-paused)
+    (var-get contract-paused)
+)
+
+;; Get the low balance threshold setting
+(define-read-only (get-low-balance-threshold)
+    (var-get low-balance-threshold)
 )

--- a/contracts/marketplace.clar
+++ b/contracts/marketplace.clar
@@ -16,10 +16,12 @@
 (define-constant err-self-purchase (err u307))
 (define-constant err-invalid-rating (err u308))
 (define-constant err-not-buyer (err u309))
+(define-constant err-marketplace-paused (err u310))
 
 ;; Marketplace fee: 2% of listing price goes to platform
 (define-data-var marketplace-fee-rate uint u200) ;; basis points (200 = 2%)
 (define-data-var total-fees-collected uint u0)
+(define-data-var marketplace-paused bool false)
 
 ;; Data Structures
 (define-map data-listings
@@ -95,6 +97,7 @@
     (tracking-contract <data-tracking-trait>))
     (let
         ((listing-id (+ (var-get listing-counter) u1))
+         (not-paused (asserts! (not (var-get marketplace-paused)) err-marketplace-paused))
          ;; Validate price and blocks-active inputs before using in map values
          (valid-price (asserts! (> price u0) err-invalid-listing))
          (valid-duration (asserts! (> blocks-active u0) err-invalid-listing))
@@ -172,6 +175,7 @@
     (tracking-contract <data-tracking-trait>))
     (let
         (;; Validate listing-id before using as map key
+         (not-paused (asserts! (not (var-get marketplace-paused)) err-marketplace-paused))
          (valid-id (asserts! (> listing-id u0) err-listing-not-found))
          (listing (unwrap! (map-get? data-listings { listing-id: listing-id })
                           err-listing-not-found)))
@@ -307,6 +311,18 @@
         (if (> (get rating-count rep) u0)
             (/ (get rating-sum rep) (get rating-count rep))
             u0)))
+
+;; Admin: toggle marketplace pause
+(define-public (set-marketplace-pause (paused bool))
+    (begin
+        (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+        (var-set marketplace-paused paused)
+        (print { action: "marketplace-pause", paused: paused })
+        (ok true)))
+
+;; Check if marketplace is paused
+(define-read-only (is-marketplace-paused)
+    (var-get marketplace-paused))
 
 ;; Admin: update marketplace fee rate (basis points)
 (define-public (set-marketplace-fee-rate (new-rate uint))

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -1,0 +1,91 @@
+---
+id: 0
+name: "Simulated deployment, used as a default for `clarinet console`, `clarinet test` and `clarinet check`"
+network: simnet
+genesis:
+  wallets:
+    - name: deployer
+      address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_1
+      address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_2
+      address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_3
+      address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_4
+      address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_5
+      address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_6
+      address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_7
+      address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_8
+      address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_9
+      address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+  contracts:
+    - genesis
+    - lockup
+    - bns
+    - cost-voting
+    - costs
+    - pox
+    - costs-2
+    - pox-2
+    - costs-3
+    - pox-3
+    - pox-4
+    - signers
+    - signers-voting
+    - costs-4
+plan:
+  batches:
+    - id: 0
+      transactions:
+        - emulated-contract-publish:
+            contract-name: data-traits
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/data-traits.clar
+            clarity-version: 3
+        - emulated-contract-publish:
+            contract-name: billing
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/billing.clar
+            clarity-version: 3
+        - emulated-contract-publish:
+            contract-name: data-tracking
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/data-tracking.clar
+            clarity-version: 3
+        - emulated-contract-publish:
+            contract-name: governance
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/governance.clar
+            clarity-version: 3
+        - emulated-contract-publish:
+            contract-name: marketplace
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/marketplace.clar
+            clarity-version: 3
+      epoch: "3.0"

--- a/tests/data-tracking_test.ts
+++ b/tests/data-tracking_test.ts
@@ -631,4 +631,86 @@ describe("data-tracking contract", () => {
     );
     expect(result).toBeErr(Cl.uint(102));
   });
+
+  it("owner can toggle emergency pause", () => {
+    const { result } = simnet.callPublicFn(
+      "data-tracking",
+      "set-emergency-pause",
+      [Cl.bool(true)],
+      deployer
+    );
+    expect(result).toBeOk(Cl.bool(true));
+
+    const paused = simnet.callReadOnlyFn("data-tracking", "is-paused", [], deployer);
+    expect(paused.result).toBeBool(true);
+  });
+
+  it("non-owner cannot toggle emergency pause", () => {
+    const { result } = simnet.callPublicFn(
+      "data-tracking",
+      "set-emergency-pause",
+      [Cl.bool(true)],
+      wallet1
+    );
+    expect(result).toBeErr(Cl.uint(100));
+  });
+
+  it("blocks plan creation when paused", () => {
+    simnet.callPublicFn("data-tracking", "set-emergency-pause", [Cl.bool(true)], deployer);
+
+    const { result } = simnet.callPublicFn(
+      "data-tracking",
+      "set-data-plan",
+      [Cl.uint(99), Cl.uint(500), Cl.uint(144), Cl.uint(50000000)],
+      deployer
+    );
+    expect(result).toBeErr(Cl.uint(109));
+
+    // Unpause for other tests
+    simnet.callPublicFn("data-tracking", "set-emergency-pause", [Cl.bool(false)], deployer);
+  });
+
+  it("blocks subscription when paused", () => {
+    simnet.callPublicFn("data-tracking", "set-data-plan",
+      [Cl.uint(88), Cl.uint(500), Cl.uint(144), Cl.uint(50000000)], deployer);
+    simnet.callPublicFn("data-tracking", "set-emergency-pause", [Cl.bool(true)], deployer);
+
+    const { result } = simnet.callPublicFn(
+      "data-tracking",
+      "subscribe-to-plan",
+      [Cl.uint(88), Cl.bool(false)],
+      wallet1
+    );
+    expect(result).toBeErr(Cl.uint(109));
+
+    simnet.callPublicFn("data-tracking", "set-emergency-pause", [Cl.bool(false)], deployer);
+  });
+
+  it("owner can set low balance threshold", () => {
+    const { result } = simnet.callPublicFn(
+      "data-tracking",
+      "set-low-balance-threshold",
+      [Cl.uint(2000)],
+      deployer
+    );
+    expect(result).toBeOk(Cl.bool(true));
+
+    const threshold = simnet.callReadOnlyFn(
+      "data-tracking",
+      "get-low-balance-threshold",
+      [],
+      deployer
+    );
+    expect(threshold.result).toBeUint(2000);
+  });
+
+  it("is-low-balance returns false for user with no plan", () => {
+    const result = simnet.callReadOnlyFn(
+      "data-tracking",
+      "is-low-balance",
+      [Cl.principal(wallet2)],
+      deployer
+    );
+    expect(result.result).toBeBool(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Add emergency pause (circuit-breaker) to data-tracking and marketplace
- Add configurable low-balance alert threshold for user data plans
- Pause blocks plan creation, subscription, listing creation, and purchases
- 6 new security-focused test cases

## Changes
- data-tracking.clar: emergency pause, low-balance alerts, is-paused read-only
- marketplace.clar: marketplace pause, is-marketplace-paused read-only
- data-tracking_test.ts: 6 new tests for pause and threshold features